### PR TITLE
Fix/prevent email loophole

### DIFF
--- a/app/src/main/java/ch/epfl/polybazaar/UI/SaleDetails.java
+++ b/app/src/main/java/ch/epfl/polybazaar/UI/SaleDetails.java
@@ -23,6 +23,7 @@ import java.util.List;
 import ch.epfl.polybazaar.R;
 import ch.epfl.polybazaar.chat.ChatActivity;
 import ch.epfl.polybazaar.listing.Listing;
+import ch.epfl.polybazaar.login.AuthenticationUtils;
 import ch.epfl.polybazaar.login.AuthenticatorFactory;
 import ch.epfl.polybazaar.map.MapsActivity;
 import ch.epfl.polybazaar.saledetails.ImageManager;
@@ -123,10 +124,7 @@ public class SaleDetails extends AppCompatActivity {
      */
 
     public void contactSeller(View v) {
-        if (AuthenticatorFactory.getDependency().getCurrentUser() == null) {
-            Intent notSignedIn = new Intent(getApplicationContext(), NotSignedIn.class);
-            startActivity(notSignedIn);
-        } else {
+        if (AuthenticationUtils.checkAccessAuthorization(this)) {
             Intent intent = new Intent(SaleDetails.this, ChatActivity.class);
             intent.putExtra(ChatActivity.BUNDLE_LISTING_ID, listingID);
             intent.putExtra(ChatActivity.BUNDLE_RECEIVER_EMAIL, listing.getUserEmail());

--- a/app/src/main/java/ch/epfl/polybazaar/UI/SaleDetails.java
+++ b/app/src/main/java/ch/epfl/polybazaar/UI/SaleDetails.java
@@ -2,7 +2,6 @@ package ch.epfl.polybazaar.UI;
 
 import android.annotation.SuppressLint;
 import android.content.Intent;
-import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.view.Gravity;
@@ -24,7 +23,6 @@ import ch.epfl.polybazaar.R;
 import ch.epfl.polybazaar.chat.ChatActivity;
 import ch.epfl.polybazaar.listing.Listing;
 import ch.epfl.polybazaar.login.AuthenticationUtils;
-import ch.epfl.polybazaar.login.AuthenticatorFactory;
 import ch.epfl.polybazaar.map.MapsActivity;
 import ch.epfl.polybazaar.saledetails.ImageManager;
 import ch.epfl.polybazaar.saledetails.ListingManager;
@@ -36,7 +34,6 @@ import static ch.epfl.polybazaar.map.MapsActivity.LAT;
 import static ch.epfl.polybazaar.map.MapsActivity.LNG;
 import static ch.epfl.polybazaar.map.MapsActivity.NOLAT;
 import static ch.epfl.polybazaar.map.MapsActivity.NOLNG;
-import static ch.epfl.polybazaar.utilities.ImageUtilities.convertStringToBitmap;
 
 public class SaleDetails extends AppCompatActivity {
 

--- a/app/src/main/java/ch/epfl/polybazaar/UI/UserProfile.java
+++ b/app/src/main/java/ch/epfl/polybazaar/UI/UserProfile.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import ch.epfl.polybazaar.R;
 import ch.epfl.polybazaar.filestorage.ImageTransaction;
 import ch.epfl.polybazaar.login.Account;
+import ch.epfl.polybazaar.login.AuthenticationUtils;
 import ch.epfl.polybazaar.login.Authenticator;
 import ch.epfl.polybazaar.login.AuthenticatorFactory;
 import ch.epfl.polybazaar.user.User;
@@ -71,10 +72,7 @@ public class UserProfile extends AppCompatActivity implements NoticeDialogListen
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_user_profile);
         authenticator = AuthenticatorFactory.getDependency();
-        if (authenticator.getCurrentUser() == null) {
-            Intent notSignedIn = new Intent(this, NotSignedIn.class);
-            startActivity(notSignedIn);
-        } else {
+        if (AuthenticationUtils.checkAccessAuthorization(this)) {
             nicknameSelector = findViewById(R.id.nicknameSelector);
             firstNameSelector = findViewById(R.id.firstNameSelector);
             lastNameSelector = findViewById(R.id.lastNameSelector);

--- a/app/src/main/java/ch/epfl/polybazaar/UI/bottomBar.java
+++ b/app/src/main/java/ch/epfl/polybazaar/UI/bottomBar.java
@@ -5,10 +5,7 @@ import android.content.Intent;
 
 import ch.epfl.polybazaar.R;
 import ch.epfl.polybazaar.conversationOverview.ConversationOverviewActivity;
-import ch.epfl.polybazaar.login.Account;
 import ch.epfl.polybazaar.login.AuthenticationUtils;
-import ch.epfl.polybazaar.login.Authenticator;
-import ch.epfl.polybazaar.login.AuthenticatorFactory;
 
 public abstract class bottomBar {
 

--- a/app/src/main/java/ch/epfl/polybazaar/UI/bottomBar.java
+++ b/app/src/main/java/ch/epfl/polybazaar/UI/bottomBar.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import ch.epfl.polybazaar.R;
 import ch.epfl.polybazaar.conversationOverview.ConversationOverviewActivity;
 import ch.epfl.polybazaar.login.Account;
+import ch.epfl.polybazaar.login.AuthenticationUtils;
 import ch.epfl.polybazaar.login.Authenticator;
 import ch.epfl.polybazaar.login.AuthenticatorFactory;
 
@@ -47,15 +48,11 @@ public abstract class bottomBar {
      * @param c the class to go to
      */
     private static void toActivity(Activity currentActivity, Class c){
-        Authenticator authenticator = AuthenticatorFactory.getDependency();
-        Account user = authenticator.getCurrentUser();
-        Intent intent;
-        if(user == null){
-            intent = new Intent(currentActivity, NotSignedIn.class);
-        }else{
-            intent = new Intent(currentActivity,c);
+        if (AuthenticationUtils.checkAccessAuthorization(currentActivity)) {
+            Intent intent = new Intent(currentActivity,c);
+            currentActivity.startActivity(intent);
+            currentActivity.overridePendingTransition(0, 0);
         }
-        currentActivity.startActivity(intent);
-        currentActivity.overridePendingTransition(0, 0);
+
     }
 }

--- a/app/src/main/java/ch/epfl/polybazaar/login/AuthenticationUtils.java
+++ b/app/src/main/java/ch/epfl/polybazaar/login/AuthenticationUtils.java
@@ -12,6 +12,13 @@ public final class AuthenticationUtils {
     // class is non-instantiable
     private AuthenticationUtils() {}
 
+    /**
+     * Checks that the user is authorized to access a resource restricted to authenticated users.
+     * If the user is not authenticated, redirects to login activity. If the user is authenticated
+     * but has not verified the email yet, redirects to email verification activity.
+     * @param ctx app context
+     * @return true if the user is signed in and has verified the email, false otherwise
+     */
     public static boolean checkAccessAuthorization(Context ctx) {
         Authenticator authenticator = AuthenticatorFactory.getDependency();
         Account user = authenticator.getCurrentUser();
@@ -29,6 +36,10 @@ public final class AuthenticationUtils {
         }
     }
 
+    /**
+     * Sends a verification e-mail to the authenticated user if possible and displays an alert message.
+     * @param ctx app context
+     */
     public static void sendVerificationEmailWithResponse(Context ctx) {
         Authenticator authenticator = AuthenticatorFactory.getDependency();
         Account user = authenticator.getCurrentUser();

--- a/app/src/main/java/ch/epfl/polybazaar/login/AuthenticationUtils.java
+++ b/app/src/main/java/ch/epfl/polybazaar/login/AuthenticationUtils.java
@@ -1,0 +1,45 @@
+package ch.epfl.polybazaar.login;
+
+import android.content.Context;
+import android.content.Intent;
+import android.widget.Toast;
+
+import ch.epfl.polybazaar.R;
+import ch.epfl.polybazaar.UI.NotSignedIn;
+import ch.epfl.polybazaar.widgets.MinimalAlertDialog;
+
+public final class AuthenticationUtils {
+    // class is non-instantiable
+    private AuthenticationUtils() {}
+
+    public static boolean checkAccessAuthorization(Context ctx) {
+        Authenticator authenticator = AuthenticatorFactory.getDependency();
+        Account user = authenticator.getCurrentUser();
+        Intent intent;
+        if (user == null) {
+            intent = new Intent(ctx, NotSignedIn.class);
+            ctx.startActivity(intent);
+            return false;
+        } else if (!user.isEmailVerified()) {
+            intent = new Intent(ctx, EmailVerificationActivity.class);
+            ctx.startActivity(intent);
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public static void sendVerificationEmailWithResponse(Context ctx) {
+        Authenticator authenticator = AuthenticatorFactory.getDependency();
+        Account user = authenticator.getCurrentUser();
+
+        user.sendEmailVerification()
+                .addOnCompleteListener(task -> {
+                    if (task.isSuccessful()) {
+                        Toast.makeText(ctx,R.string.verification_email_sent, Toast.LENGTH_LONG).show();
+                    } else {
+                        MinimalAlertDialog.makeDialog(ctx, R.string.verification_email_fail);
+                    }
+                });
+    }
+}

--- a/app/src/main/java/ch/epfl/polybazaar/login/EmailVerificationActivity.java
+++ b/app/src/main/java/ch/epfl/polybazaar/login/EmailVerificationActivity.java
@@ -20,7 +20,6 @@ public class EmailVerificationActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_email_verification);
         authenticator = AuthenticatorFactory.getDependency();
-        verify(getCurrentFocus());
     }
 
     @Override
@@ -40,21 +39,7 @@ public class EmailVerificationActivity extends AppCompatActivity {
      * @param view view that triggers the action
      */
     public void verify(View view) {
-        Account user = authenticator.getCurrentUser();
-        user.sendEmailVerification()
-                .addOnCompleteListener(this, task -> {
-                    if (task.isSuccessful()) {
-                        Toast.makeText(
-                                EmailVerificationActivity.this,
-                                R.string.verification_email_sent, Toast.LENGTH_LONG
-                        ).show();
-                    } else {
-                        MinimalAlertDialog.makeDialog(
-                                EmailVerificationActivity.this,
-                                R.string.verification_email_fail
-                        );
-                    }
-                });
+        AuthenticationUtils.sendVerificationEmailWithResponse(this);
     }
 
     /**

--- a/app/src/main/java/ch/epfl/polybazaar/login/EmailVerificationActivity.java
+++ b/app/src/main/java/ch/epfl/polybazaar/login/EmailVerificationActivity.java
@@ -21,18 +21,6 @@ public class EmailVerificationActivity extends AppCompatActivity {
         authenticator = AuthenticatorFactory.getDependency();
     }
 
-    @Override
-    protected void onStop() {
-        super.onStop();
-        Account user = authenticator.getCurrentUser();
-        /*
-        if (user != null && !user.isEmailVerified()) {
-            authenticator.signOut();
-            // TODO delete the user
-        }
-         */
-    }
-
     /**
      * Attempts to send a verification email to the user
      * @param view view that triggers the action

--- a/app/src/main/java/ch/epfl/polybazaar/login/EmailVerificationActivity.java
+++ b/app/src/main/java/ch/epfl/polybazaar/login/EmailVerificationActivity.java
@@ -1,11 +1,10 @@
 package ch.epfl.polybazaar.login;
 
-import androidx.appcompat.app.AppCompatActivity;
-
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
-import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import ch.epfl.polybazaar.R;
 import ch.epfl.polybazaar.widgets.MinimalAlertDialog;

--- a/app/src/main/java/ch/epfl/polybazaar/login/SignUpActivity.java
+++ b/app/src/main/java/ch/epfl/polybazaar/login/SignUpActivity.java
@@ -96,6 +96,7 @@ public class SignUpActivity extends AppCompatActivity {
         authenticator.createUser(email, nickname, password)
                 .addOnCompleteListener(this, task -> {
                     if (task.isSuccessful()) {
+                        AuthenticationUtils.sendVerificationEmailWithResponse(this);
                         Intent intent = new Intent(getApplicationContext(), EmailVerificationActivity.class);
                         startActivity(intent);
                     } else {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="signup_email_invalid">Please enter a valid EPFL e-mail address</string>
     <string name="signup_nickname_invalid">Please enter a valid nickname</string>
     <string name="verification_email_sent">Verification e-mail sent</string>
-    <string name="verification_email_fail">Unable to send verification e-mail</string>
+    <string name="verification_email_fail">Unable to send verification e-mail. A verification e-mail has probably been sent already. Check your inbox and try again in a few minutes</string>
     <string name="reload_fail">Unable to reload</string>
     <string name="contact_the_seller">Contact Seller</string>
     <string name="title">Listing Title</string>


### PR DESCRIPTION
This PR aims to prevent users with an unverified e-mail address to access content that can only be accessed by authenticated users. If a user tries to access such a resource before having verified the email address, the user is redirected to the e-mail verification activity. Additionally, all verifications (user is signed in and e-mail is verified) are now performed in a centralized way with the `checkAccessAuthorization` method.